### PR TITLE
Support firefox 46+

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,6 +14,12 @@
 		"48": "icons/icon48.png",
 		"128": "icons/icon128.png"
 	},
+	"applications": {
+		"gecko": {
+			"id": "@tbf-extension",
+			"strict_min_version": "46.0.0"
+		}
+	},
 	"manifest_version": 2,
 	"name": "Twitch Buffering Fix",
 	"permissions": ["contextMenus", "webRequest", "webRequestBlocking", "http://*.hls.ttvnw.net/*", "http://*.hls.twitch.tv/*"],


### PR DESCRIPTION
Hi,

Firefox recently added WebExtensions addon API which allow porting Chrome
extensions easily to Firefox.
This extension works on Firefox 46 with a minor addition to the
manifest.json file so Firefox is able to load it.

WebExtensions is implemented since Firefox 45 but the required methods
used here are available since Firefox 46.

So I'm proposing this modification so this extension can work on both Chrome and Firefox.

On Chrome, the extension still load properly but shows "Unrecognized manifest key 'applications'" because of the Firefox new stuff in the manifest.
Maybe the manifest for Firefox and Chrome should be separated then ?